### PR TITLE
fix: resolve lint and Docker build failures

### DIFF
--- a/agent-runner/Dockerfile
+++ b/agent-runner/Dockerfile
@@ -30,8 +30,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user.
-RUN groupadd -g 1000 agent && useradd -m -u 1000 -g agent agent
+# Create non-root user (remove default ubuntu user that occupies UID 1000).
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && groupadd -g 1000 agent \
+    && useradd -m -u 1000 -g agent agent
 
 # Create required directories.
 RUN mkdir -p /agent/output /agent/workspace && \

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -377,8 +377,8 @@ func (r *AgentRunReconciler) extractOutput(pod *corev1.Pod) string {
 	return ""
 }
 
-func boolPtr(b bool) *bool       { return &b }
-func int64Ptr(i int64) *int64    { return &i }
+func boolPtr(b bool) *bool    { return &b }
+func int64Ptr(i int64) *int64 { return &i }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AgentRunReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
## Summary
- Fix gofmt alignment on `boolPtr`/`int64Ptr` helper functions (caused lint CI failure)
- Remove default `ubuntu` user (UID 1000) in agent-runner Dockerfile before creating `agent` user (caused Docker build exit code 4)

## Test plan
- [ ] Lint workflow passes
- [ ] Build and Push Images workflow passes (both operator and agent-runner)