### PR TITLE
fix: change agent-runner image default from :latest to :main

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ kubectl logs -n agent-system -l agents.wearn.dev/task=add-healthcheck -f
 | `spec.repository.branch` | Base branch | `main` |
 | `spec.repository.workBranch` | Branch for agent changes | `ai/<task-name>` |
 | `spec.prompt` | Task instructions | required |
-| `spec.agentImage` | Container image for agent pods | `ghcr.io/jcwearn/agent-runner:latest` |
+| `spec.agentImage` | Container image for agent pods | `ghcr.io/jcwearn/agent-runner:main` |
 | `spec.resources.cpu` | CPU limit per agent pod | `4` |
 | `spec.resources.memory` | Memory limit per agent pod | `8Gi` |
 | `spec.anthropicApiKeyRef` | Secret reference for Anthropic API key | required |

--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -58,7 +58,7 @@ type AgentRunSpec struct {
 	Prompt string `json:"prompt"`
 
 	// image is the container image for the agent pod.
-	// +kubebuilder:default="ghcr.io/jcwearn/agent-runner:latest"
+	// +kubebuilder:default="ghcr.io/jcwearn/agent-runner:main"
 	// +optional
 	Image string `json:"image,omitempty"`
 

--- a/api/v1alpha1/codingtask_types.go
+++ b/api/v1alpha1/codingtask_types.go
@@ -147,7 +147,7 @@ type CodingTaskSpec struct {
 	Prompt string `json:"prompt"`
 
 	// agentImage is the container image for agent pods.
-	// +kubebuilder:default="ghcr.io/jcwearn/agent-runner:latest"
+	// +kubebuilder:default="ghcr.io/jcwearn/agent-runner:main"
 	// +optional
 	AgentImage string `json:"agentImage,omitempty"`
 

--- a/config/crd/bases/agents.wearn.dev_agentruns.yaml
+++ b/config/crd/bases/agents.wearn.dev_agentruns.yaml
@@ -74,8 +74,9 @@ spec:
                   test error output from a failed run, etc.).
                 type: string
               gitCredentialsRef:
-                description: gitCredentialsRef references the Secret containing Git
-                  credentials.
+                description: |-
+                  gitCredentialsRef references the Secret containing Git credentials.
+                  Optional when the operator is configured with a GitHub App (tokens are minted automatically).
                 properties:
                   key:
                     description: key is the key within the Secret.
@@ -88,7 +89,7 @@ spec:
                 - name
                 type: object
               image:
-                default: ghcr.io/jcwearn/agent-runner:latest
+                default: ghcr.io/jcwearn/agent-runner:main
                 description: image is the container image for the agent pod.
                 type: string
               prompt:
@@ -155,7 +156,6 @@ spec:
                 type: string
             required:
             - anthropicApiKeyRef
-            - gitCredentialsRef
             - prompt
             - repository
             - step

--- a/config/crd/bases/agents.wearn.dev_codingtasks.yaml
+++ b/config/crd/bases/agents.wearn.dev_codingtasks.yaml
@@ -56,7 +56,7 @@ spec:
             description: CodingTaskSpec defines the desired state of CodingTask.
             properties:
               agentImage:
-                default: ghcr.io/jcwearn/agent-runner:latest
+                default: ghcr.io/jcwearn/agent-runner:main
                 description: agentImage is the container image for agent pods.
                 type: string
               anthropicApiKeyRef:
@@ -74,8 +74,9 @@ spec:
                 - name
                 type: object
               gitCredentialsRef:
-                description: gitCredentialsRef references the Secret containing Git
-                  credentials (e.g., GitHub token).
+                description: |-
+                  gitCredentialsRef references the Secret containing Git credentials (e.g., GitHub token).
+                  Optional when the operator is configured with a GitHub App (tokens are minted automatically).
                 properties:
                   key:
                     description: key is the key within the Secret.
@@ -235,7 +236,6 @@ spec:
                 type: array
             required:
             - anthropicApiKeyRef
-            - gitCredentialsRef
             - prompt
             - repository
             - source

--- a/config/samples/agents_v1alpha1_codingtask.yaml
+++ b/config/samples/agents_v1alpha1_codingtask.yaml
@@ -16,7 +16,7 @@ spec:
     url: https://github.com/jcwearn/example-repo.git
     branch: main
   prompt: "Add a health check endpoint to the API server at /healthz that returns a 200 OK"
-  agentImage: ghcr.io/jcwearn/agent-runner:latest
+  agentImage: ghcr.io/jcwearn/agent-runner:main
   resources:
     cpu: "4"
     memory: "8Gi"


### PR DESCRIPTION
## Summary
- Changes the default `agentImage` in CodingTask and AgentRun CRDs from `:latest` to `:main`
- CI produces `:main` tags (via `docker/metadata-action` with `type=ref,event=branch`), not `:latest`
- The `:latest` tag doesn't exist on GHCR, causing `ImagePullBackOff` on agent pods

## Test plan
- [ ] Merge and verify new operator image is built
- [ ] Create a CodingTask and confirm the agent pod pulls `agent-runner:main` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)