### PR TITLE
feat: make testing optional via plan comment checkbox

### DIFF
--- a/api/v1alpha1/codingtask_types.go
+++ b/api/v1alpha1/codingtask_types.go
@@ -270,6 +270,11 @@ type CodingTaskStatus struct {
 	// +optional
 	AgentRuns []AgentRunReference `json:"agentRuns,omitempty"`
 
+	// runTests indicates whether the testing step should run.
+	// Set during plan approval based on the checkbox in the plan comment.
+	// +optional
+	RunTests bool `json:"runTests,omitempty"`
+
 	// planCommentID is the GitHub comment ID where the plan was posted,
 	// used for tracking approval reactions.
 	// +optional

--- a/config/crd/bases/agents.wearn.dev_codingtasks.yaml
+++ b/config/crd/bases/agents.wearn.dev_codingtasks.yaml
@@ -418,6 +418,11 @@ spec:
                 description: retryCount tracks how many retries have been attempted
                   for the current step.
                 type: integer
+              runTests:
+                description: |-
+                  runTests indicates whether the testing step should run.
+                  Set during plan approval based on the checkbox in the plan comment.
+                type: boolean
               startedAt:
                 description: startedAt is when the task began processing.
                 format: date-time


### PR DESCRIPTION
## Summary

- Testing is now **skipped by default** in the agent workflow (4 steps instead of 5)
- Plan comments include an unchecked `- [ ] Run tests before creating PR` checkbox
- When a reviewer approves (thumbs-up), the controller fetches the comment body and parses the checkbox state
- If checked, the workflow runs all 5 steps including testing; if unchecked, it skips directly from Implementation to Pull Request
- The API `/tasks/{name}/approve` endpoint also accepts an optional `runTests` JSON field

## Files changed

- `api/v1alpha1/codingtask_types.go` — Added `RunTests` field to `CodingTaskStatus`
- `internal/github/notifier.go` — Checkbox in plan comment, checkbox parsing in `CheckApproval`
- `internal/controller/codingtask_controller.go` — Updated `ApprovalChecker` interface, branching logic in `handleImplementing`, extracted `createPullRequestRun` helper
- `internal/server/handlers_tasks.go` — Accept `runTests` in approve endpoint
- CRD manifests regenerated

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `make test` passes
- [ ] Verify plan comment renders checkbox correctly on a GitHub issue
- [ ] Approve without checking box → workflow skips Testing (4/4)
- [ ] Approve with box checked → workflow runs Testing (4/5, 5/5)
- [ ] API approve with `{"runTests": true}` → runs tests
- [ ] API approve with empty body → skips tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)