### PR TITLE
fix: use gh auth login for reliable CLI auth in agent runner

### DIFF
--- a/agent-runner/entrypoint.sh
+++ b/agent-runner/entrypoint.sh
@@ -52,13 +52,17 @@ log "Repository: ${AGENT_REPO_URL}"
 log "Base branch: ${AGENT_BASE_BRANCH}"
 log "Work branch: ${AGENT_WORK_BRANCH}"
 
-# Configure git credentials.
-git config --global credential.helper store
-REPO_HOST=$(echo "$AGENT_REPO_URL" | sed -n 's|https://\([^/]*\)/.*|\1|p')
-echo "https://oauth2:${GIT_TOKEN}@${REPO_HOST}" > ~/.git-credentials
+# Configure git identity.
 git config --global user.email "agent@wearn.dev"
 git config --global user.name "Agent Operator"
+
+# Authenticate GitHub CLI and configure git to use it for credentials.
+# This is more reliable in containers than GH_TOKEN env var alone, since
+# gh auth login writes a persistent config that survives subprocess spawning.
 export GH_TOKEN="$GIT_TOKEN"
+echo "$GIT_TOKEN" | gh auth login --with-token 2>&1 || fail "gh auth login failed"
+gh auth setup-git 2>&1 || fail "gh auth setup-git failed"
+log "GitHub CLI authenticated: $(gh auth status 2>&1 | head -1)"
 
 # Clone the repository.
 log "Cloning repository..."


### PR DESCRIPTION
## Summary

- Replace manual `~/.git-credentials` setup with `gh auth login --with-token` + `gh auth setup-git`
- The previous approach set `GH_TOKEN` env var and wrote `~/.git-credentials` for `credential.helper store`. This worked for `git push` but `gh pr create` uses the GitHub API separately and wasn't reliably picking up auth in the container environment — causing PR creation to fail while branch pushes succeeded.
- `gh auth login --with-token` writes persistent auth config, and `gh auth setup-git` configures git to use `gh` as the credential helper, making both git operations and `gh` CLI API calls work reliably.

## Test plan

- [ ] Build and push new `agent-runner` image
- [ ] Deploy and trigger a task that goes through the full workflow to PR creation
- [ ] Verify `gh auth status` log line appears in agent runner pod logs
- [ ] Verify PR is created successfully by the pull-request agent step

🤖 Generated with [Claude Code](https://claude.com/claude-code)