### PR TITLE
fix: set imagePullPolicy Always on agent runner pods

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -265,8 +265,9 @@ func (r *AgentRunReconciler) createPod(ctx context.Context, run *agentsv1alpha1.
 			},
 			Containers: []corev1.Container{
 				{
-					Name:  "agent",
-					Image: run.Spec.Image,
+					Name:            "agent",
+					Image:           run.Spec.Image,
+					ImagePullPolicy: corev1.PullAlways,
 					Env: []corev1.EnvVar{
 						{
 							Name: "ANTHROPIC_API_KEY",


### PR DESCRIPTION
The agent-runner image uses the :main tag, and Kubernetes defaults to IfNotPresent for non-:latest tags. This means nodes cache the image and won't pull updates. Setting PullAlways ensures new agent pods always get the latest image.