### PR TITLE
fix: make approval/feedback detection resilient to reactions API errors

### DIFF
--- a/internal/controller/codingtask_controller.go
+++ b/internal/controller/codingtask_controller.go
@@ -283,6 +283,10 @@ func (r *CodingTaskReconciler) handleAwaitingApproval(ctx context.Context, task 
 		task.Status.CurrentStep = 1
 		task.Status.RetryCount = 0
 		task.Status.PlanCommentID = nil
+		// Clear "plan-ready" from NotifiedPhases so the revised plan comment gets posted.
+		task.Status.NotifiedPhases = slices.DeleteFunc(task.Status.NotifiedPhases, func(s string) bool {
+			return s == "plan-ready"
+		})
 		task.Status.Message = "Re-planning with reviewer feedback"
 		r.broadcast(task)
 


### PR DESCRIPTION
## Summary

- **CheckApproval resilience**: If `ListIssueCommentReactions` errors (e.g. GitHub App permissions), the error is now logged and the function falls through to check comment feedback instead of returning early. This was the primary bug causing tasks to get stuck in `AwaitingApproval`.
- **Re-plan deduplication fix**: When transitioning to re-plan after feedback, `"plan-ready"` is now cleared from `NotifiedPhases` so the revised plan comment actually gets posted and `PlanCommentID` is set correctly.
- **issue_comment webhook handler**: Added `IssueCommentEvent` handling to the webhook endpoint. When a comment is posted on an issue with an `AwaitingApproval` task, the task is annotated to trigger immediate reconciliation instead of waiting for the 30s poll cycle.

Fixes jcwearn/k3s-cluster#280

## Test plan

- [ ] `go build ./...` and `go test ./...` pass
- [ ] Create a CodingTask, wait for plan, add thumbs-up → should transition to implementing
- [ ] Create a CodingTask, wait for plan, add comment feedback → should transition to re-planning
- [ ] Verify operator logs show no persistent "failed to check approval" errors
- [ ] Verify issue_comment webhook triggers immediate reconciliation (check logs for "triggered reconciliation for issue comment")

🤖 Generated with [Claude Code](https://claude.com/claude-code)