### PR TITLE
feat: add semver release workflows

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -40,6 +40,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=sha
 
       - name: Build and push operator
@@ -79,6 +80,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=sha
 
       - name: Build and push agent-runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump
+        id: bump
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const releaseLabel = labels.find(l => l.startsWith('release:'));
+            if (!releaseLabel) {
+              core.setFailed('No release label found on merged PR');
+              return;
+            }
+            const bump = releaseLabel.replace('release:', '');
+            core.setOutput('type', bump);
+            core.info(`Bump type: ${bump}`);
+
+      - name: Get latest tag and compute next version
+        id: version
+        run: |
+          LATEST=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+          if [ -z "$LATEST" ]; then
+            LATEST="v0.0.0"
+          fi
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+
+          # Strip leading 'v'
+          VERSION="${LATEST#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          BUMP="${{ steps.bump.outputs.type }}"
+          case "$BUMP" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEXT="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Previous: $LATEST → Next: $NEXT"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.next }}" \
+            --target main \
+            --title "${{ steps.version.outputs.next }}" \
+            --generate-notes \
+            --notes-start-tag "${{ steps.version.outputs.latest }}"

--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -1,0 +1,23 @@
+name: Require Release Label
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for release label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const releaseLabels = labels.filter(l => l.startsWith('release:'));
+            if (releaseLabels.length === 0) {
+              core.setFailed('PR must have a release label: release:major, release:minor, or release:patch');
+            } else if (releaseLabels.length > 1) {
+              core.setFailed('PR must have exactly one release label, found: ' + releaseLabels.join(', '));
+            } else {
+              core.info('Release label found: ' + releaseLabels[0]);
+            }


### PR DESCRIPTION
## Summary
- Add `require-release-label.yml` workflow to enforce exactly one `release:{major,minor,patch}` label on PRs
- Add `release.yml` workflow to auto-create git tags and GitHub releases when PRs are merged
- Update `build-images.yml` to produce `major.minor` tags alongside existing `version` and `sha` tags

## Flow
```
PR opened → must have exactly one release:{major,minor,patch} label
PR merged → release workflow reads label, bumps version, creates git tag (v1.2.3)
Tag push  → build-images.yml builds + pushes images tagged 1.2.3, 1.2, and sha-*
```

## Test plan
- [ ] Open a test PR without a label — CI check should fail
- [ ] Add `release:patch` label — CI check should pass
- [ ] Merge — release workflow creates tag and GitHub release
- [ ] Check GHCR — images tagged with semver

🤖 Generated with [Claude Code](https://claude.com/claude-code)