### PR TITLE
fix: conditionally omit --notes-start-tag for first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          NOTES_FLAG=""
+          if [ "${{ steps.version.outputs.latest }}" != "v0.0.0" ]; then
+            NOTES_FLAG="--notes-start-tag ${{ steps.version.outputs.latest }}"
+          fi
           gh release create "${{ steps.version.outputs.next }}" \
             --target main \
             --title "${{ steps.version.outputs.next }}" \
             --generate-notes \
-            --notes-start-tag "${{ steps.version.outputs.latest }}"
+            $NOTES_FLAG


### PR DESCRIPTION
## Summary
- Fix release workflow failing with `HTTP 400: Invalid previous_tag parameter` when no prior tags exist
- Conditionally omit `--notes-start-tag` when the latest tag is the synthetic `v0.0.0` fallback
- This was the root cause of the failed release after PR #15 was merged

## Test plan
- [ ] Merge this PR, then manually create v0.1.0 release
- [ ] Verify build-images.yml triggers on the v0.1.0 tag
- [ ] Verify future PRs with `release:patch` label produce v0.1.1 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)