### PR TITLE
fix: inline image build+push into release workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,52 +1,25 @@
-name: Build and Push Images
+name: Build Images (CI)
 
 on:
   pull_request:
     branches: [main]
-  workflow_dispatch:
-
-env:
-  REGISTRY: ghcr.io
-  OPERATOR_IMAGE: ghcr.io/${{ github.repository_owner }}/agent-operator
-  RUNNER_IMAGE: ghcr.io/${{ github.repository_owner }}/agent-runner
 
 jobs:
   build-operator:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.OPERATOR_IMAGE }}
-          tags: |
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-
-      - name: Build and push operator
+      - name: Build operator
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -54,37 +27,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.RUNNER_IMAGE }}
-          tags: |
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-
-      - name: Build and push agent-runner
+      - name: Build agent-runner
         uses: docker/build-push-action@v6
         with:
           context: ./agent-runner
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,19 @@ on:
     types: [closed]
     branches: [main]
 
+env:
+  REGISTRY: ghcr.io
+  OPERATOR_IMAGE: ghcr.io/${{ github.repository_owner }}/agent-operator
+  RUNNER_IMAGE: ghcr.io/${{ github.repository_owner }}/agent-runner
+
 jobs:
   release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.version.outputs.next }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -78,8 +85,86 @@ jobs:
             --generate-notes \
             $NOTES_FLAG
 
-      - name: Trigger image build
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-operator:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.version }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute tags
+        id: tags
         run: |
-          gh workflow run build-images.yml --ref "${{ steps.version.outputs.next }}"
+          VERSION="${{ needs.release.outputs.version }}"
+          SEMVER="${VERSION#v}"
+          MAJOR_MINOR="${SEMVER%.*}"
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          TAGS="${{ env.OPERATOR_IMAGE }}:${SEMVER}"
+          TAGS="${TAGS},${{ env.OPERATOR_IMAGE }}:${MAJOR_MINOR}"
+          TAGS="${TAGS},${{ env.OPERATOR_IMAGE }}:sha-${SHORT_SHA}"
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push operator
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-agent-runner:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.version }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute tags
+        id: tags
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          SEMVER="${VERSION#v}"
+          MAJOR_MINOR="${SEMVER%.*}"
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          TAGS="${{ env.RUNNER_IMAGE }}:${SEMVER}"
+          TAGS="${TAGS},${{ env.RUNNER_IMAGE }}:${MAJOR_MINOR}"
+          TAGS="${TAGS},${{ env.RUNNER_IMAGE }}:sha-${SHORT_SHA}"
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push agent-runner
+        uses: docker/build-push-action@v6
+        with:
+          context: ./agent-runner
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Inlines Docker build+push jobs directly into `release.yml`, eliminating the `gh workflow run` dispatch that fails with HTTP 403 (GITHUB_TOKEN cannot trigger other workflows)
- Simplifies `build-images.yml` to PR-only CI validation (`push: false`, no GHCR login, no `packages: write`)
- Images are tagged with semver (`0.0.x`), major.minor (`0.x`), and `sha-<short>` (no `latest`)

## Test plan
- [ ] Merge a PR with a `release:patch` label and verify the Release workflow creates the release AND builds+pushes both images (3 jobs)
- [ ] Check GHCR for images tagged with semver, major.minor, and sha
- [ ] Open a non-release PR and confirm `Build Images (CI)` runs both builds with `push: false`
- [ ] Confirm `workflow_dispatch` trigger is removed from `build-images.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)