### PR TITLE
fix: wire up PRStatusChecker for auto-closing issues

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -267,6 +267,7 @@ func main() {
 	if ghNotifier != nil {
 		codingTaskReconciler.Notifier = ghNotifier
 		codingTaskReconciler.ApprovalChecker = ghNotifier
+		codingTaskReconciler.PRStatusChecker = ghNotifier
 	}
 	codingTaskReconciler.Broadcaster = &hubBroadcaster{hub: apiServer.GetHub()}
 


### PR DESCRIPTION
## Summary

- Wire up `PRStatusChecker` on `CodingTaskReconciler` in `cmd/main.go` so that merged PRs auto-close their tracking issues
- `ghNotifier` already implements the `PRStatusChecker` interface but the field was never assigned, causing `checkPRMergeStatus` to bail at its nil guard

**Root cause:** [k3s-cluster#297](https://github.com/jcwearn/k3s-cluster/issues/297) was not auto-closed after PR [k3s-cluster#298](https://github.com/jcwearn/k3s-cluster/pull/298) was merged because the reconciler could never detect the merge.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/ ./internal/github/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)