### PR TITLE
feat: process GitHub issue attachments in agent runner

### DIFF
--- a/agent-runner/Dockerfile
+++ b/agent-runner/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     gnupg \
     jq \
+    file \
     && rm -rf /var/lib/apt/lists/*
 
 # Node.js (LTS) for Claude Code CLI.


### PR DESCRIPTION
## Summary
- Download and resolve GitHub issue file attachments (text + images) before invoking Claude
- Text files are inlined into the prompt (capped at 100KB per file); images are saved to `/agent/workspace/attachments/` so Claude can read them via its Read tool
- Added `file` package to Dockerfile for MIME type detection fallback when extensions are ambiguous

## Test plan
- [ ] Verify Docker image builds successfully in CI
- [ ] Create a test GitHub issue with a `.yaml` text attachment and confirm it gets inlined into the prompt
- [ ] Create a test GitHub issue with a `.png` image attachment and confirm it gets saved to disk with a Read tool hint
- [ ] Verify that a failed download logs a warning and leaves the original markdown link intact
- [ ] Verify prompts with no attachments pass through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)