### PR TITLE
fix: use PAT for private repo attachment downloads

### DIFF
--- a/agent-runner/entrypoint.sh
+++ b/agent-runner/entrypoint.sh
@@ -87,10 +87,13 @@ process_attachments() {
 
         # Strategy 1: Authenticated redirect resolution (private repos).
         # Request with auth but don't follow redirects to get the pre-signed S3 URL.
-        if [ -n "${GIT_TOKEN:-}" ]; then
+        # Prefer GITHUB_PAT (a real PAT) over GIT_TOKEN (which may be a GitHub App
+        # installation token that lacks access to user-attachments URLs).
+        local auth_token="${GITHUB_PAT:-${GIT_TOKEN:-}}"
+        if [ -n "$auth_token" ]; then
             local redirect_url
             redirect_url=$(curl -s \
-                -H "Authorization: Bearer $GIT_TOKEN" \
+                -H "Authorization: Bearer $auth_token" \
                 -H "User-Agent: agent-runner/1.0" \
                 -o /dev/null -w '%{redirect_url}' \
                 "$url" 2>/dev/null) || true


### PR DESCRIPTION
## Summary

- Injects `GITHUB_PAT` env var from `GitCredentialsRef` when both a GitHub App (`GitTokenProvider`) and a PAT secret are configured
- `entrypoint.sh` prefers `GITHUB_PAT` over `GIT_TOKEN` for attachment auth, since GitHub App installation tokens lack access to `user-attachments/` URLs on private repos
- `GITHUB_PAT` is optional — no change in behavior when only one auth method is configured

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] Deploy with both GitHub App and `GitCredentialsRef` PAT secret configured
- [ ] Create a task from a private repo issue with attachments
- [ ] Verify the pod has both `GIT_TOKEN` and `GITHUB_PAT` env vars
- [ ] Verify attachments download successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)